### PR TITLE
When no search results but other tab has some, show a hint.

### DIFF
--- a/src/containers/sidebar/pprf-sidebar-search-container.vue
+++ b/src/containers/sidebar/pprf-sidebar-search-container.vue
@@ -29,6 +29,7 @@
                     :count="programs.length"
                     :selected="true"
                    >
+                    <div v-if="programs.length > 0">
                       <pprf-program-card
                         v-if="program.id"
                         v-for="program in programs"
@@ -44,6 +45,10 @@
                         :withinZipcode="program.within_zip_code"
                         :distance="program.distance"
                       />
+                    </div>
+                    <div v-else-if="facilities.length > 0">
+                      No activities were found. Try the <b>Locations</b> tab above.
+                    </div>
 
                   </pprf-tab>
 
@@ -51,6 +56,7 @@
                     name="Locations"
                     :count="facilities.length"
                   >
+                    <div v-if="facilities.length > 0">
                       <pprf-location-card
                         v-for="facility in facilities"
                         :key="getUUID('facilityCard')"
@@ -62,6 +68,10 @@
                         :selected="activeCardID === facility.id"
                         :withinZipcode="facility.within_zip_code"
                       />
+                    </div>
+                    <div v-else-if="programs.length > 0">
+                      No locations were found. Try the <b>Activities</b> tab above.
+                    </div>
                   </pprf-tab>
 
               </pprf-tabs>


### PR DESCRIPTION
Per #65. The default view is activities. If none are found in the search, but there are location results, it shows this hint. Same thing for when there are no locations but there are activities (more rare). When there are no results in either tab, no message is shown (which is the current functionality).

I'd prefer it automatically switch tabs, but I spent 2 hours trying to do that this morning to no avail. Tabs are strange in vue. Short of that, I'd prefer you could click "Locations" instead of it telling you to "try the tab above," but it's more complex than just a link. This is a lot better than no feedback at all in my opinion.

Please feel free to merge after you review.

![screen shot 2018-01-25 at 07 35 29](https://user-images.githubusercontent.com/761444/35388587-62ed74bc-01a2-11e8-977a-8c56b184990c.png)

(It's an odd feeling to spend 2 hours and ultimately write 4 lines of code...lol)