### PR TITLE
Hotfix for zipcode on initial search

### DIFF
--- a/src/components/search/pprf-search.vue
+++ b/src/components/search/pprf-search.vue
@@ -265,10 +265,6 @@ export default {
      * @since 0.3.7
      */
     '$route.query': function (val) {
-      if (_.difference([val.freetext], [this.$store.state.search.fields.freetext]).length) {
-        val.zip = null
-        val.address = null
-      }
       this.searchFromRoute(val)
     }
   }


### PR DESCRIPTION
I'm not sure what this logic was for in the first place, or why it didn't cause an issue earlier. Removing it fixes #199.