### PR TITLE
Add pollyfill for IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/fontawesome-free-solid": "^5.0.10",
     "@fortawesome/vue-fontawesome": "0.0.22",
     "axios": "^0.18.0",
+    "babel-polyfill": "^6.26.0",
     "camelcase-keys": "^3.0.0",
     "date-fns": "^1.29.0",
     "esri-leaflet": "^2.1.4",

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import 'babel-polyfill';
+import 'babel-polyfill'
 
 import Vue from 'vue'
 import { sync } from 'vuex-router-sync'

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+import 'babel-polyfill';
+
 import Vue from 'vue'
 import { sync } from 'vuex-router-sync'
 import Meta from 'vue-meta'


### PR DESCRIPTION
I just realized v2 doesn't work in IE. You might want to only load the specific polyfills we're are using, but considering the timeline this is most expedient. 